### PR TITLE
Fixing the default behavior when to set NonTTYUI.

### DIFF
--- a/ui/conf_ui.go
+++ b/ui/conf_ui.go
@@ -16,10 +16,14 @@ func NewConfUI(logger ExternalLogger) *ConfUI {
 
 	writerUI := NewConsoleUI(logger)
 	ui = NewPaddingUI(writerUI)
+	isTTY := writerUI.IsTTY()
+	if !isTTY {
+		ui = NewNonTTYUI(ui)
+	}
 
 	return &ConfUI{
 		parent: ui,
-		isTTY:  writerUI.IsTTY(),
+		isTTY:  isTTY,
 		logger: logger,
 	}
 }
@@ -33,7 +37,7 @@ func NewWrappingConfUI(parent UI, logger ExternalLogger) *ConfUI {
 }
 
 func (ui *ConfUI) EnableTTY(force bool) {
-	if !ui.isTTY && !force {
+	if !force {
 		ui.parent = NewNonTTYUI(ui.parent)
 	}
 }


### PR DESCRIPTION
1. Fixing the default behavior when to set NonTTYUI.

Scenario | TTY Value in go-cli-ui | UI Initialized by go-cli-ui
-- | -- | --
CLI cmd with output to terminal and args tty=true | True | Padding UI
CLI cmd with output to terminal and args tty=false | False | NonTTYUI
CLI cmd with output not to terminal and args tty=true | False | NonTTYUI
CLI cmd with output not to terminal and args tty=false | False | NonTTYUI
