### PR TITLE
Print error block and avoid panic when headers are not found.

### DIFF
--- a/ui/conf_ui.go
+++ b/ui/conf_ui.go
@@ -82,7 +82,7 @@ func (ui *ConfUI) PrintTable(table Table) {
 	if len(ui.showColumns) > 0 {
 		err := table.SetColumnVisibility(ui.showColumns)
 		if err != nil {
-			panic(err)
+			ui.parent.PrintErrorBlock(err.Error())
 		}
 	}
 

--- a/ui/table/headers.go
+++ b/ui/table/headers.go
@@ -44,7 +44,7 @@ func (t *Table) SetColumnVisibility(headers []Header) error {
 	}
 
 	if len(missingHeaders) > 0 {
-		return fmt.Errorf("failed to find following headers: %s", strings.Join(missingHeaders, ", "))
+		return fmt.Errorf("warning: failed to find following headers: %s", strings.Join(missingHeaders, ", "))
 	}
 	return nil
 }

--- a/ui/table/headers.go
+++ b/ui/table/headers.go
@@ -21,6 +21,7 @@ func (t *Table) SetColumnVisibility(headers []Header) error {
 		t.Header[tableHeaderIdx].Hidden = true
 	}
 
+	missingHeaders := []string{}
 	for _, header := range headers {
 		foundHeader := false
 
@@ -34,11 +35,17 @@ func (t *Table) SetColumnVisibility(headers []Header) error {
 		}
 
 		if !foundHeader {
-			// key may be empty; if title is present
-			return fmt.Errorf("Failed to find header: %s", header.Key)
+			if header.Key != "" {
+				missingHeaders = append(missingHeaders, header.Key)
+			} else if header.Title != "" {
+				missingHeaders = append(missingHeaders, header.Title)
+			}
 		}
 	}
 
+	if len(missingHeaders) > 0 {
+		return fmt.Errorf("failed to find following headers: %s", strings.Join(missingHeaders, ", "))
+	}
 	return nil
 }
 


### PR DESCRIPTION
Print error block and avoid panic when headers are not found.